### PR TITLE
fix: edit the strapi postStart wget command to be on a single line

### DIFF
--- a/microservices/strapi/dev-public-catalog/values.yaml
+++ b/microservices/strapi/dev-public-catalog/values.yaml
@@ -80,12 +80,7 @@ deployment:
         echo "Registering admin if not exists..."
 
         HTTP_CODE=$(
-          wget --server-response --header="Content-Type: application/json" --post-data="{
-            \"email\":\"${STRAPI_ADMIN_EMAIL}\",
-            \"password\":\"${STRAPI_ADMIN_PASSWORD}\",
-            \"firstname\":\"${STRAPI_ADMIN_FIRSTNAME}\",
-            \"lastname\":\"${STRAPI_ADMIN_LASTNAME}\"
-          }" http://127.0.0.1:1337/admin/register-admin -O - 2>&1 | grep "HTTP/" | tail -1 | sed -E 's/.*HTTP\/[0-9.]+ ([0-9]+).*/\1/'
+          wget --server-response --header="Content-Type: application/json" --post-data='{"email":"'"${STRAPI_ADMIN_EMAIL}"'","password":"'"${STRAPI_ADMIN_PASSWORD}"'","firstname":"'"${STRAPI_ADMIN_FIRSTNAME}"'","lastname":"'"${STRAPI_ADMIN_LASTNAME}"'"}' http://127.0.0.1:1337/admin/register-admin -O - 2>&1 | grep "HTTP/" | tail -1 | sed -E 's/.*HTTP\/[0-9.]+ ([0-9]+).*/\1/'
         )
 
         if [ "$HTTP_CODE" = "200" ]; then

--- a/microservices/strapi/prod-public-catalog/values.yaml
+++ b/microservices/strapi/prod-public-catalog/values.yaml
@@ -80,12 +80,7 @@ deployment:
         echo "Registering admin if not exists..."
 
         HTTP_CODE=$(
-          wget --server-response --header="Content-Type: application/json" --post-data="{
-            \"email\":\"${STRAPI_ADMIN_EMAIL}\",
-            \"password\":\"${STRAPI_ADMIN_PASSWORD}\",
-            \"firstname\":\"${STRAPI_ADMIN_FIRSTNAME}\",
-            \"lastname\":\"${STRAPI_ADMIN_LASTNAME}\"
-          }" http://127.0.0.1:1337/admin/register-admin -O - 2>&1 | grep "HTTP/" | tail -1 | sed -E 's/.*HTTP\/[0-9.]+ ([0-9]+).*/\1/'
+          wget --server-response --header="Content-Type: application/json" --post-data='{"email":"'"${STRAPI_ADMIN_EMAIL}"'","password":"'"${STRAPI_ADMIN_PASSWORD}"'","firstname":"'"${STRAPI_ADMIN_FIRSTNAME}"'","lastname":"'"${STRAPI_ADMIN_LASTNAME}"'"}' http://127.0.0.1:1337/admin/register-admin -O - 2>&1 | grep "HTTP/" | tail -1 | sed -E 's/.*HTTP\/[0-9.]+ ([0-9]+).*/\1/'
         )
 
         if [ "$HTTP_CODE" = "200" ]; then


### PR DESCRIPTION
This PR edits the wget command in the postStart hook to be on a single line, otherwise it gets the following error:

> Error: read ECONNRESET
> at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
> at TCP.callbackTrampoline (node:internal/async_hooks:130:17)