### PR TITLE
fix: add GRANT TRUNCATE on tables to public_catalog_updater_user

### DIFF
--- a/commons/dev-public-catalog/configmaps/flyway-public-catalog.yaml
+++ b/commons/dev-public-catalog/configmaps/flyway-public-catalog.yaml
@@ -31,7 +31,7 @@ data:
       CONSTRAINT eservice_id_metadata_version_unique UNIQUE (id, metadata_version)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor (
@@ -55,7 +55,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref (
@@ -67,7 +67,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor_attribute (
@@ -82,7 +82,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_astro_frontend_user";
 
   V1.1__tenant_Schema.sql: |-
@@ -110,7 +110,7 @@ data:
       CONSTRAINT tenant_id_metadata_version_unique UNIQUE (id, metadata_version)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_astro_frontend_user";
 
   V1.2__attribute_Schema.sql: |-
@@ -135,7 +135,7 @@ data:
       PRIMARY KEY (id)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_astro_frontend_user";
 
   V1.3__search_fts_trgm.sql: |-

--- a/commons/prod-public-catalog/configmaps/flyway-public-catalog.yaml
+++ b/commons/prod-public-catalog/configmaps/flyway-public-catalog.yaml
@@ -31,7 +31,7 @@ data:
       CONSTRAINT eservice_id_metadata_version_unique UNIQUE (id, metadata_version)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor (
@@ -55,7 +55,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref (
@@ -67,7 +67,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_template_version_ref TO "${NAMESPACE}_astro_frontend_user";
 
     CREATE TABLE IF NOT EXISTS "${NAMESPACE}_catalog".eservice_descriptor_attribute (
@@ -82,7 +82,7 @@ data:
       FOREIGN KEY (eservice_id, metadata_version) REFERENCES "${NAMESPACE}_catalog".eservice (id, metadata_version) DEFERRABLE INITIALLY DEFERRED
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_catalog".eservice_descriptor_attribute TO "${NAMESPACE}_astro_frontend_user";
 
   V1.1__tenant_Schema.sql: |-
@@ -110,7 +110,7 @@ data:
       CONSTRAINT tenant_id_metadata_version_unique UNIQUE (id, metadata_version)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_tenant".tenant TO "${NAMESPACE}_astro_frontend_user";
 
   V1.2__attribute_Schema.sql: |-
@@ -135,12 +135,12 @@ data:
       PRIMARY KEY (id)
     );
 
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_public_catalog_updater_user";
+    GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_public_catalog_updater_user";
     GRANT SELECT ON TABLE "${NAMESPACE}_attribute".attribute TO "${NAMESPACE}_astro_frontend_user";
 
   V1.3__search_fts_trgm.sql: |-
-    CREATE EXTENSION IF NOT EXISTS unaccent;
-    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
+    CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
     DO $$
     BEGIN
@@ -158,7 +158,7 @@ data:
       SELECT trim(
         regexp_replace(
           lower(
-            regexp_replace(unaccent(coalesce(t,'')), '\.', '', 'g')
+            regexp_replace(public.unaccent(coalesce(t,'')), '\.', '', 'g')
           ),
             '[^a-z0-9]+', ' ', 'g'
         )


### PR DESCRIPTION
This PR adds the `GRANT TRUNCATE` on tables to `public_catalog_updater_user`.
It also update the `V1.3__search_fts_trgm.sql` migration in prod environment by referencing the `public` schema.