### PR TITLE
fix: edit cronjob schedule

### DIFF
--- a/jobs/public-catalog-updater/dev-public-catalog/values.yaml
+++ b/jobs/public-catalog-updater/dev-public-catalog/values.yaml
@@ -8,7 +8,7 @@ configmap:
   CDN_INVALIDATION_PATH: "/catalogo/*" #TBD
 
 cronjob:
-  schedule: "0 20 * * *"
+  schedule: "0 8-20 * * 1-5"
   timeZone: "Europe/Rome"
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 1

--- a/jobs/public-catalog-updater/prod-public-catalog/values.yaml
+++ b/jobs/public-catalog-updater/prod-public-catalog/values.yaml
@@ -8,7 +8,7 @@ configmap:
   CDN_INVALIDATION_PATH: "/catalogo/*" #TBD
 
 cronjob:
-  schedule: "0 20 * * *"
+  schedule: "0 * * * *"
   timeZone: "Europe/Rome"
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 1

--- a/jobs/public-catalog-updater/prod-public-catalog/values.yaml
+++ b/jobs/public-catalog-updater/prod-public-catalog/values.yaml
@@ -8,7 +8,7 @@ configmap:
   CDN_INVALIDATION_PATH: "/catalogo/*" #TBD
 
 cronjob:
-  schedule: "0 * * * *"
+  schedule: "0 1 * * *"
   timeZone: "Europe/Rome"
   failedJobsHistoryLimit: 2
   successfulJobsHistoryLimit: 1


### PR DESCRIPTION
This PR edits the `public-catalog-updater` cronjob schedule.
Specifically, the schedule is set to:
- every hour from 8:00 to 20:00 from Monday to Friday in **DEV** (because there will be a similar schedule on the Aurora cluster as well for cost-optimization purposes);
- once per day at 01:00 AM in **PROD**.