### PR TITLE
fix(strapi): edit CDN_URL env for strapi in DEV

### DIFF
--- a/microservices/strapi/dev-public-catalog/values.yaml
+++ b/microservices/strapi/dev-public-catalog/values.yaml
@@ -14,7 +14,7 @@ service:
 configmap:
   DATABASE_CLIENT: "postgres"
   DATABASE_SSL_REJECT_UNAUTHORIZED: "false"
-  CDN_URL: "api-gov.dev.interop.pagopa.it"
+  CDN_URL: "https://api-gov.dev.interop.pagopa.it"
   CDN_ROOT_PATH: "cms-assets/"
   AWS_REGION: "eu-south-1"
   AWS_BUCKET: "interop-public-catalog-cms-assets-dev-es1"


### PR DESCRIPTION
This PR edits the `CDN_URL` env in strapi by adding the `https://` schema to the URL.
This edit affects how the `upload-aws-s3` plugin behavior when loading/getting images: https://github.com/pagopa/interop-public-catalog/blob/develop/packages/strapi/config/plugins.ts#L6
