### PR TITLE
chore: apply remediation for untrusted GitHub Actions inputs

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -42,23 +42,23 @@ jobs:
       - name: Print Inputs
         id: print_inputs
         env:
-          PRINT_INPUT_ENVIRONMENT: ${{ inputs.environment }}
-          PRINT_INPUT_REF: ${{ github.ref }}
-          PRINT_INPUT_RUN_K8S_WORKFLOW: ${{ inputs.run_k8s_workflow }}
-          PRINT_INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW: ${{ inputs.run_tf_apply_monitoring_workflow }}
-          PRINT_INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW: ${{ inputs.run_tf_apply_secrets_workflow }}
-          PRINT_INPUT_RUN_INVALIDATE_CACHE: ${{ inputs.run_invalidate_cache }}
-          PRINT_INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV: ${{ vars.HELM_FORCE_UPGRADE_MICROSERVICES_CSV }}
-          PRINT_INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV: ${{ vars.HELM_FORCE_UPGRADE_CRONJOBS_CSV }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
+          INPUT_REF: ${{ github.ref }}
+          INPUT_RUN_K8S_WORKFLOW: ${{ inputs.run_k8s_workflow }}
+          INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW: ${{ inputs.run_tf_apply_monitoring_workflow }}
+          INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW: ${{ inputs.run_tf_apply_secrets_workflow }}
+          INPUT_RUN_INVALIDATE_CACHE: ${{ inputs.run_invalidate_cache }}
+          INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV: ${{ vars.HELM_FORCE_UPGRADE_MICROSERVICES_CSV }}
+          INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV: ${{ vars.HELM_FORCE_UPGRADE_CRONJOBS_CSV }}
         run: |
-          echo "- environment: \`$PRINT_INPUT_ENVIRONMENT\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ref: \`$PRINT_INPUT_REF\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- run_k8s_workflow: \`$PRINT_INPUT_RUN_K8S_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- run_tf_apply_monitoring_workflow: \`$PRINT_INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- run_tf_apply_secrets_workflow: \`$PRINT_INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- run_invalidate_cache: \`$PRINT_INPUT_RUN_INVALIDATE_CACHE\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- HELM_FORCE_UPGRADE_MICROSERVICES_CSV: \`$PRINT_INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- HELM_FORCE_UPGRADE_CRONJOBS_CSV: \`$PRINT_INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- environment: \`$INPUT_ENVIRONMENT\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ref: \`$INPUT_REF\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_k8s_workflow: \`$INPUT_RUN_K8S_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_tf_apply_monitoring_workflow: \`$INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_tf_apply_secrets_workflow: \`$INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_invalidate_cache: \`$INPUT_RUN_INVALIDATE_CACHE\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- HELM_FORCE_UPGRADE_MICROSERVICES_CSV: \`$INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- HELM_FORCE_UPGRADE_CRONJOBS_CSV: \`$INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV\`" >> "$GITHUB_STEP_SUMMARY"
 
   initChecks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -41,15 +41,24 @@ jobs:
     steps:
       - name: Print Inputs
         id: print_inputs
+        env:
+          PRINT_INPUT_ENVIRONMENT: ${{ inputs.environment }}
+          PRINT_INPUT_REF: ${{ github.ref }}
+          PRINT_INPUT_RUN_K8S_WORKFLOW: ${{ inputs.run_k8s_workflow }}
+          PRINT_INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW: ${{ inputs.run_tf_apply_monitoring_workflow }}
+          PRINT_INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW: ${{ inputs.run_tf_apply_secrets_workflow }}
+          PRINT_INPUT_RUN_INVALIDATE_CACHE: ${{ inputs.run_invalidate_cache }}
+          PRINT_INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV: ${{ vars.HELM_FORCE_UPGRADE_MICROSERVICES_CSV }}
+          PRINT_INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV: ${{ vars.HELM_FORCE_UPGRADE_CRONJOBS_CSV }}
         run: |
-          echo "- environment: \`${{ inputs.environment }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- ref: \`${{ github.ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- run_k8s_workflow: \`${{ inputs.run_k8s_workflow }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- run_tf_apply_monitoring_workflow: \`${{ inputs.run_tf_apply_monitoring_workflow }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- run_tf_apply_secrets_workflow: \`${{ inputs.run_tf_apply_secrets_workflow }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- run_invalidate_cache: \`${{ inputs.run_invalidate_cache }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- HELM_FORCE_UPGRADE_MICROSERVICES_CSV: \`${{ vars.HELM_FORCE_UPGRADE_MICROSERVICES_CSV }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- HELM_FORCE_UPGRADE_CRONJOBS_CSV: \`${{ vars.HELM_FORCE_UPGRADE_CRONJOBS_CSV }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- environment: \`$PRINT_INPUT_ENVIRONMENT\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ref: \`$PRINT_INPUT_REF\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_k8s_workflow: \`$PRINT_INPUT_RUN_K8S_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_tf_apply_monitoring_workflow: \`$PRINT_INPUT_RUN_TF_APPLY_MONITORING_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_tf_apply_secrets_workflow: \`$PRINT_INPUT_RUN_TF_APPLY_SECRETS_WORKFLOW\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- run_invalidate_cache: \`$PRINT_INPUT_RUN_INVALIDATE_CACHE\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- HELM_FORCE_UPGRADE_MICROSERVICES_CSV: \`$PRINT_INPUT_HELM_FORCE_UPGRADE_MICROSERVICES_CSV\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- HELM_FORCE_UPGRADE_CRONJOBS_CSV: \`$PRINT_INPUT_HELM_FORCE_UPGRADE_CRONJOBS_CSV\`" >> "$GITHUB_STEP_SUMMARY"
 
   initChecks:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-validation-main.yaml
+++ b/.github/workflows/pr-validation-main.yaml
@@ -15,9 +15,9 @@ jobs:
       - name: Print Inputs
         id: print_inputs
         env:
-          PRINT_INPUT_GITHUB_REF: ${{ github.ref }}
+          INPUT_GITHUB_REF: ${{ github.ref }}
         run: |
-          echo "- Github ref: \`$PRINT_INPUT_GITHUB_REF\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Github ref: \`$INPUT_GITHUB_REF\`" >> "$GITHUB_STEP_SUMMARY"
 
 
   extract-infra-commons-tag:

--- a/.github/workflows/pr-validation-main.yaml
+++ b/.github/workflows/pr-validation-main.yaml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - name: Print Inputs
         id: print_inputs
+        env:
+          PRINT_INPUT_GITHUB_REF: ${{ github.ref }}
         run: |
-          echo "- Github ref: \`${{ github.ref }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Github ref: \`$PRINT_INPUT_GITHUB_REF\`" >> "$GITHUB_STEP_SUMMARY"
 
 
   extract-infra-commons-tag:


### PR DESCRIPTION
This PR applies a remediation for untrusted GitHub Actions inputs by passing workflow values through environment variables before using them in shell steps.